### PR TITLE
Fix command builder bugs

### DIFF
--- a/GitSyncMaster/Private/UI/Show-CommandBuilder.ps1
+++ b/GitSyncMaster/Private/UI/Show-CommandBuilder.ps1
@@ -41,8 +41,10 @@ function Show-CommandBuilder {
         Update-CommandBuilderOptions
     }
     
-    # Track if we should show tooltips
-    $script:AppState.ShowTooltips = $true
+    # Ensure ShowTooltips state exists but don't override user preference
+    if (-not [bool]($script:AppState.PSObject.Properties.Name -match 'ShowTooltips')) {
+        $script:AppState | Add-Member -NotePropertyName ShowTooltips -NotePropertyValue $true
+    }
     
     # Show current command
     Move-Cursor -Row $Y -Column $X

--- a/GitSyncMaster/Public/Show-GitSyncTUI.ps1
+++ b/GitSyncMaster/Public/Show-GitSyncTUI.ps1
@@ -369,9 +369,14 @@ function Handle-UserInput {
                     }
                 }
                 'Backspace' {
-                    # Remove last command part
+                    # Remove last command part safely
                     if ($script:AppState.CommandParts.Count -gt 0) {
-                        $script:AppState.CommandParts = $script:AppState.CommandParts[0..($script:AppState.CommandParts.Count-2)]
+                        if ($script:AppState.CommandParts.Count -eq 1) {
+                            $script:AppState.CommandParts = @()
+                        }
+                        else {
+                            $script:AppState.CommandParts = $script:AppState.CommandParts[0..($script:AppState.CommandParts.Count - 2)]
+                        }
                         $script:AppState.SelectedIndex = 0
                         Update-CommandBuilderOptions
                     }

--- a/GitSyncMaster/Show-GitSyncTUI.ps1
+++ b/GitSyncMaster/Show-GitSyncTUI.ps1
@@ -365,9 +365,14 @@ function Handle-UserInput {
                     }
                 }
                 'Backspace' {
-                    # Remove last command part
+                    # Remove last command part safely
                     if ($script:AppState.CommandParts.Count -gt 0) {
-                        $script:AppState.CommandParts = $script:AppState.CommandParts[0..($script:AppState.CommandParts.Count-2)]
+                        if ($script:AppState.CommandParts.Count -eq 1) {
+                            $script:AppState.CommandParts = @()
+                        }
+                        else {
+                            $script:AppState.CommandParts = $script:AppState.CommandParts[0..($script:AppState.CommandParts.Count - 2)]
+                        }
                         $script:AppState.SelectedIndex = 0
                         Update-CommandBuilderOptions
                     }


### PR DESCRIPTION
## Summary
- preserve user tooltip preferences when redrawing command builder
- handle removing last command part without errors

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683f5732e12883238e5e6295dec3df35