### PR TITLE
Fix Draw-Box parameters

### DIFF
--- a/GitSyncMaster/GitSyncTUI.psm1
+++ b/GitSyncMaster/GitSyncTUI.psm1
@@ -136,34 +136,7 @@ function script:Draw-Box {
         [Parameter(Mandatory)]
         [int]$X,
         
-        [Parameter(Mandvisory)]
-        [int]$Column
-    )
-    
-    Write-Host "$script:EscChar[$Row;${Column}H" -NoNewline
-}
-
-function script:Clear-Screen {
-    [CmdletBinding()]
-    param()
-    
-    Write-Host (Get-ANSIEscape -Code 'Clear') -NoNewline
-}
-
-function script:Clear-Line {
-    [CmdletBinding()]
-    param()
-    
-    Write-Host (Get-ANSIEscape -Code 'ClearLine') -NoNewline
-}
-
-function script:Draw-Box {
-    [CmdletBinding()]
-    param(
         [Parameter(Mandatory)]
-        [int]$X,
-        
-        [Parameter(Mandvisory)]
         [int]$Y,
         
         [Parameter(Mandatory)]


### PR DESCRIPTION
## Summary
- remove duplicate function definitions in `GitSyncTUI.psm1`
- fix `Draw-Box` parameter attributes

## Testing
- `powershell -NoProfile -Command "Test-ModuleManifest ./GitSyncMaster/GitSyncTUI.psd1"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840997f92ec83238202bee9e8ad131e