### PR TITLE
Fix ShowTooltips initialization

### DIFF
--- a/GitSyncMaster/Private/UI/Show-CommandBuilder.ps1
+++ b/GitSyncMaster/Private/UI/Show-CommandBuilder.ps1
@@ -42,8 +42,8 @@ function Show-CommandBuilder {
     }
     
     # Ensure ShowTooltips state exists but don't override user preference
-    if (-not [bool]($script:AppState.PSObject.Properties.Name -match 'ShowTooltips')) {
-        $script:AppState | Add-Member -NotePropertyName ShowTooltips -NotePropertyValue $true
+    if (-not $script:AppState.ContainsKey('ShowTooltips')) {
+        $script:AppState['ShowTooltips'] = $true
     }
     
     # Show current command


### PR DESCRIPTION
## Summary
- avoid overwriting existing `ShowTooltips` setting in `Show-CommandBuilder`

## Testing
- `pwsh -NoLogo -NoProfile -Command '$script:AppState=@{}; $script:AppState.ShowTooltips=$false; if(-not $script:AppState.ContainsKey("ShowTooltips")){ $script:AppState["ShowTooltips"]=$true}; $script:AppState.ShowTooltips'`

------
https://chatgpt.com/codex/tasks/task_e_68409981b20883239ad398ecf514c7c3